### PR TITLE
[WIP] Small Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # GeoTrellis Chattanooga model demo 
 
-This is a demo of GeoTrellis functionality. Demo consists of two parts: tile ingest process and demo server to query ingested data.
+This is a demo of GeoTrellis functionality.
+The demo consists of two parts: the tile ingest process and demo server to query ingested data.
 
 To run ingest, use `./ingest.sh`, to run server, use `./run-server.sh`. Web map would be available here `http://locahost:8777/`. 
 
 ## Short description
 
-Demo covers [Chattanooga](https://goo.gl/S2qPCO) with different `Byte` tiles. In fact it's a `Bit` type (each tile has values `{0, 1}`). 
-Each tile is ingests into it's own layer and the result map consists of layers combination with different weights (it is called weighted overlay).  
+The demo covers [Chattanooga](https://goo.gl/S2qPCO) with different `Byte` tiles.
+(In fact each tile is essentially of type `Bit` because they only contain the  values `{0, 1}`).
+Each tile is ingests into it's own layer, and the resulting map consists of layers which consist of combinations of differently-weighted source layers (a weighted overlay).  
 
 ### API routes:
 
@@ -43,9 +45,9 @@ Calculates breaks for combined layers by weights with specified breaks amount.
 
 *Get Parameters:* `layers`, `weights`, `breaks`, `bbox`, `colors: [default: 4]`, `colorRamp: [default: "blue-to-red"]`, `mask`.
 
-It is a TMS layer service that gets `{zoom}/{x}/{y}`, passed a series of layer names and weights, and returns PNG tms tiles of the weighted overlay. 
+It is a TMS layer service that gets `{zoom}/{x}/{y}`, passed a series of layer names and weights, and returns PNG TMS tiles of the weighted overlay. 
 It also takes the breaks that were computed using the `gt/breaks` service. 
-If the `mask` option is set to a polygon, `{zoom}/{x}/{y}` tiles masked by polygon would be returned.
+If the `mask` option is set to a polygon, `{zoom}/{x}/{y}` tiles masked by that polygon would be returned.
 
 ### Zonal Summary:
 
@@ -56,14 +58,15 @@ It will compute a weighted summary of the area under the polygon.
 
 ## Runing demo using [GeoDocker cluster](https://github.com/geodocker/geodocker)
 
-To compile and run this demo, we prepared an [environment](https://github.com/geodocker/geodocker). To run cluster we have a bit modified [docker-compose.yml](docker-compose.yml) file:
+To compile and run this demo, we prepared an [environment](https://github.com/geodocker/geodocker).
+To run cluster we have a slightly-modified [docker-compose.yml](docker-compose.yml) file:
 
 * To run cluster:
   ```bash
     docker-compose up
   ```
   
-  To check that cluster is operating normally check pages availability: 
+  To check that cluster is operating normally check the availability of these pages:
   * Hadoop [http://localhost:50070/](http://localhost:50070/)
   * Accumulo [http://localhost:50095/](http://localhost:50095/)
   * Spark [http://localhost:8080/](http://localhost:8080/)

--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ To compile and run this demo, we prepared an [environment](https://github.com/ge
   * Copy everything into spark master container:
 
     ```bash
-      cd ./geodocker
+      cd ./geotrellis
+      ./sbt assembly
       docker exec geotrellischattademo_spark-master_1 mkdir -p /data/target/scala-2.10/
-      docker cp target/scala-2.10/GeoTrellis-Tutorial-Project-assembly-0.1-SNAPSHOT.jar geotrellischattademo_spark-master_1:/data/target/scala-2.10/GeoTrellis-Tutorial-Project-assembly-0.1-SNAPSHOT.jar
+      docker cp target/scala-2.11/GeoTrellis-Tutorial-Project-assembly-0.1-SNAPSHOT.jar geotrellischattademo_spark-master_1:/data/target/scala-2.10/GeoTrellis-Tutorial-Project-assembly-0.1-SNAPSHOT.jar
+      docker cp  ../static geotrellischattademo_spark-master_1:/static
       docker cp data/arg_wm/ geotrellischattademo_spark-master_1:/data/
       docker cp conf geotrellischattademo_spark-master_1:/data/
       docker cp ingest.sh geotrellischattademo_spark-master_1:/data/

--- a/geotrellis/build.sbt
+++ b/geotrellis/build.sbt
@@ -1,8 +1,7 @@
 import scala.util.Properties
 
 name := "GeoTrellis-Tutorial-Project"
-scalaVersion := Properties.propOrElse("scala.version", "2.10.6")
-crossScalaVersions := Seq("2.11.8", "2.10.6")
+scalaVersion := "2.11.8"
 organization := "com.azavea"
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 scalacOptions ++= Seq(


### PR DESCRIPTION
Before merging this, the issue of Scala 2.11 versus Scala 2.10 should be resolved, because these changes would make the `build.sbt` file and the `README` inconsistent/incompatible for the non-GeoDocker case.

I had to use Scala 2.11 in solve the following error, which was preventing the ingest:
```
Exception in thread "main" java.lang.NoSuchMethodError: scala.reflect.api.JavaUniverse.runtimeMirror(Ljava/lang/ClassLoader;)Lscala/reflect/api/JavaMirrors$JavaMirror;
        at geotrellis.spark.etl.s3.S3Module$.<init>(S3Module.scala:6)
        at geotrellis.spark.etl.s3.S3Module$.<clinit>(S3Module.scala)
        at geotrellis.spark.etl.Etl$.<init>(Etl.scala:27)
        at geotrellis.spark.etl.Etl$.<clinit>(Etl.scala)
        at geotrellis.chatta.ChattaIngest$delayedInit$body.apply(ChattaIngest.scala:15)
        at scala.Function0$class.apply$mcV$sp(Function0.scala:34)
        at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:12)
        at scala.App$$anonfun$main$1.apply(App.scala:76)
        at scala.App$$anonfun$main$1.apply(App.scala:76)
        at scala.collection.immutable.List.foreach(List.scala:381)
        at scala.collection.generic.TraversableForwarder$class.foreach(TraversableForwarder.scala:35)
        at scala.App$class.main(App.scala:76)
        at geotrellis.chatta.ChattaIngest$.main(ChattaIngest.scala:12)
        at geotrellis.chatta.ChattaIngest.main(ChattaIngest.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.apache.spark.deploy.SparkSubmit$.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:729)
        at org.apache.spark.deploy.SparkSubmit$.doRunMain$1(SparkSubmit.scala:185)
        at org.apache.spark.deploy.SparkSubmit$.submit(SparkSubmit.scala:210)
        at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:124)
        at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```
