### PR TITLE
Add Terraform deployment resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ TAGS
 *.iml
 *.sublime-workspace
 .DS_Store
+
+# Vagrant
+.vagrant
 deployment/ansible/roles/azavea.*
 service/geotrellis/data/chatta-demo
 service/geotrellis/project/boot
@@ -20,4 +23,8 @@ service/geotrellis/project/plugins/target
 service/geotrellis/project/target
 service/geotrellis/target
 ingest-data.zip
-.vagrant
+
+# Terraform
+deployment/terraform/.terraform
+*.tfplan
+*.tfstate*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+sudo: required
+language: bash
+cache:
+  directories:
+  - ${HOME}/.ivy2
+  - ${HOME}/.m2
+  - ${HOME}/.sbt
+services: docker
+env:
+  global:
+  - TERRAFORM_VERSION=0.9.6
+  - AWSCLI_VERSION=1.11.*
+  - DOCKER_COMPOSE_VERSION=1.13.*
+  - GT_CHATTA_SETTINGS_BUCKET=geotrellis-site-production-config-us-east-1
+  - AWS_DEFAULT_REGION=us-east-1
+  - secure: T4Wgz/5ZiqIKOh6kxxeCHMwfqPZGn/5zsuCPz+4qdESQvsiuKqVZ1XtagZG5F8Q49ztrdvxWJmCAWZjuuHSRID28mzTgpGe2X1RrQd4D0AW/I9ajLoy57dymxp4AaSWgr0DcaPqRPzlHwmEj2EEYD+jegg50lfHD3R5JlUKlJ+w=
+  - secure: Cstj/BLZCU1+jVuG2WwYDDD8noeoLQ53WlT5z8AW0YTqdwhFArN2WoBozp1mE/W7mr+rCE+brYAQoSsozRjMp9PYzKb4tdGlFGrodyZHoVWVFW///GUPb8oVpindCsyFC+aN0Q8M8MUP2C61GE5UqosS3+iDUQhX1c0O8NHXPEs=
+  - secure: AaGydeuJdzzyFSCQW/m3vXGfwdm6JMmTIP8mVI3OoIo+ZFnGoMra4pHBEg5X13gnujGvwTFMQ85TREm9FSLb1RN5QdGRi9p6zcfS9rNvRp2CzFxfazV4QONFmwxC6gTVIQA98Ni51SFoM9yt3umlUDWoedyn9ShGaPt6jTdqxHU=
+  - secure: WHV8Lxl7jnVsGMgXju/BSAUkNesDUC1UKqH5kYk5aAnpdCf6YQaFqc7oVvCnymKJx32A3YN9lhhXO5rqhQB9UPff8W4U/cNHrgksbVxj/rQHj2nRj1hb/sXlXxySU/bRb9l4OnbEHIxNExVHiBtrL8T+xFy9dzYCWpYD3rmXT+c=
+script:
+- mkdir -p ~/.local/bin
+- export PATH="~/.local/bin:$PATH"
+- pip install --user docker-compose==${DOCKER_COMPOSE_VERSION}
+- scripts/cibuild
+before_deploy:
+- wget -O terraform-${TERRAFORM_VERSION}.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+- unzip -d ~/.local/bin terraform-${TERRAFORM_VERSION}.zip
+- pip install --user awscli==${AWSCLI_VERSION}
+- rm terraform-${TERRAFORM_VERSION}.zip
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: scripts/deploy
+  on:
+    branch: master
+after_deploy:
+- rm deployment/terraform/${GT_CHATTA_SETTINGS_BUCKET}.tfplan

--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -1,0 +1,62 @@
+resource "aws_cloudfront_distribution" "cdn" {
+  origin {
+    domain_name = "${aws_route53_record.origin.fqdn}"
+    origin_id   = "originChattaSite"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+    }
+  }
+
+  enabled          = true
+  http_version     = "http2"
+  comment          = "GeoTrellis Chattanooga Demo (${var.environment})"
+  retain_on_delete = true
+
+  price_class = "${var.cdn_price_class}"
+
+  # The trailing period at the end of the name is stripped off to comply with CloudFront's CNAME policy.
+  aliases = ["chatta.${replace(data.aws_route53_zone.external.name, "/.$/", "")}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "originChattaSite"
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    compress               = false
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 300
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${data.terraform_remote_state.core.logs_bucket_id}.s3.amazonaws.com"
+    prefix          = "CloudFront/Chatta/"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "${var.ssl_certificate_arn}"
+    minimum_protocol_version = "TLSv1"
+    ssl_support_method       = "sni-only"
+  }
+}

--- a/deployment/terraform/chatta-demo.tf
+++ b/deployment/terraform/chatta-demo.tf
@@ -1,0 +1,55 @@
+#
+# ECS Resources
+#
+
+# Template for container definition, allows us to inject environment
+data "template_file" "ecs_chatta_task" {
+  template = "${file("${path.module}/task-definitions/chatta.json")}"
+
+  vars {
+    chatta_image       = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/gt-chatta:${var.image_version}"
+    chatta_region      = "${var.aws_region}"
+    chatta_environment = "${var.environment}"
+  }
+}
+
+# Allows resource sharing among multiple containers
+resource "aws_ecs_task_definition" "chatta" {
+  family                = "${var.environment}Chatta"
+  container_definitions = "${data.template_file.ecs_chatta_task.rendered}"
+}
+
+resource "aws_cloudwatch_log_group" "chatta" {
+  name = "log${var.environment}ChattaDemo"
+
+  tags {
+    Environment = "${var.environment}"
+  }
+}
+
+module "chatta_ecs_service" {
+  source = "github.com/azavea/terraform-aws-ecs-web-service?ref=0.2.0"
+
+  name                = "Chatta"
+  vpc_id              = "${data.terraform_remote_state.core.vpc_id}"
+  public_subnet_ids   = ["${data.terraform_remote_state.core.public_subnet_ids}"]
+  access_log_bucket   = "${data.terraform_remote_state.core.logs_bucket_id}"
+  access_log_prefix   = "ALB/Chatta"
+  port                = "8777"
+  ssl_certificate_arn = "${var.ssl_certificate_arn}"
+
+  cluster_name                   = "${data.terraform_remote_state.core.container_instance_name}"
+  task_definition_id             = "${aws_ecs_task_definition.chatta.family}:${aws_ecs_task_definition.chatta.revision}"
+  desired_count                  = "${var.chatta_ecs_desired_count}"
+  min_count                      = "${var.chatta_ecs_min_count}"
+  max_count                      = "${var.chatta_ecs_max_count}"
+  deployment_min_healthy_percent = "${var.chatta_ecs_deployment_min_percent}"
+  deployment_max_percent         = "${var.chatta_ecs_deployment_max_percent}"
+  container_name                 = "gt-chatta"
+  container_port                 = "8777"
+  ecs_service_role_name          = "${data.terraform_remote_state.core.ecs_service_role_name}"
+  ecs_autoscale_role_arn         = "${data.terraform_remote_state.core.ecs_autoscale_role_arn}"
+
+  project     = "Geotrellis Chatta"
+  environment = "${var.environment}"
+}

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  backend "s3" {
+    region  = "us-east-1"
+    encrypt = "true"
+  }
+}

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -1,0 +1,27 @@
+#
+# Public DNS resources
+#
+
+resource "aws_route53_record" "origin" {
+  zone_id = "${data.aws_route53_zone.external.id}"
+  name    = "chatta-origin.${data.aws_route53_zone.external.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${lower(module.chatta_ecs_service.lb_dns_name)}"
+    zone_id                = "${module.chatta_ecs_service.lb_zone_id}"
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "cloudfront" {
+  zone_id = "${data.aws_route53_zone.external.id}"
+  name    = "chatta.${data.aws_route53_zone.external.name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_cloudfront_distribution.cdn.domain_name}"
+    zone_id                = "${aws_cloudfront_distribution.cdn.hosted_zone_id}"
+    evaluate_target_health = false
+  }
+}

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -1,0 +1,45 @@
+#
+# Website ALB security group resources
+#
+resource "aws_security_group_rule" "alb_chatta_https_ingress" {
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${module.chatta_ecs_service.lb_security_group_id}"
+}
+
+resource "aws_security_group_rule" "alb_chatta_container_instance_all_egress" {
+  type      = "egress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = "${module.chatta_ecs_service.lb_security_group_id}"
+  source_security_group_id = "${data.terraform_remote_state.core.container_instance_security_group_id}"
+}
+
+#
+# Container instance security group resources
+#
+resource "aws_security_group_rule" "container_instance_alb_chatta_all_ingress" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = "${data.terraform_remote_state.core.container_instance_security_group_id}"
+  source_security_group_id = "${module.chatta_ecs_service.lb_security_group_id}"
+}
+
+resource "aws_security_group_rule" "container_instance_alb_chatta_all_egress" {
+  type      = "egress"
+  from_port = 0
+  to_port   = 65535
+  protocol  = "tcp"
+
+  security_group_id        = "${data.terraform_remote_state.core.container_instance_security_group_id}"
+  source_security_group_id = "${module.chatta_ecs_service.lb_security_group_id}"
+}

--- a/deployment/terraform/remote-state.tf
+++ b/deployment/terraform/remote-state.tf
@@ -1,0 +1,13 @@
+data "terraform_remote_state" "core" {
+  backend = "s3"
+
+  config {
+    region = "${var.aws_region}"
+    bucket = "${var.remote_state_bucket}"
+    key    = "terraform/core/state"
+  }
+}
+
+data "aws_route53_zone" "external" {
+  zone_id = "${data.terraform_remote_state.core.public_hosted_zone_id}"
+}

--- a/deployment/terraform/task-definitions/chatta.json
+++ b/deployment/terraform/task-definitions/chatta.json
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "gt-chatta",
+        "image": "${chatta_image}",
+        "cpu": 10,
+        "memory": 2048,
+        "essential": true,
+        "portMappings": [
+            {
+                "containerPort": 8777,
+                "hostPort": 0
+            }
+        ],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "log${chatta_environment}ChattaDemo",
+                "awslogs-region": "${chatta_region}",
+                "awslogs-stream-prefix": "chatta-demo"
+            }
+        }
+    }
+]

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -9,7 +9,7 @@ variable "remote_state_bucket" {
 
 variable "aws_account_id" {
   default     = "896538046175"
-  description = "Geotrellis Transit account ID"
+  description = "Geotrellis Chatta account ID"
 }
 
 variable "aws_region" {
@@ -18,7 +18,7 @@ variable "aws_region" {
 
 variable "image_version" {
   type        = "string"
-  description = "Geotrellis Transit Image version"
+  description = "Geotrellis Chatta Image version"
 }
 
 variable "cdn_price_class" {

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,0 +1,50 @@
+variable "environment" {
+  default = "Production"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "Core infrastructure config bucket"
+}
+
+variable "aws_account_id" {
+  default     = "896538046175"
+  description = "Geotrellis Transit account ID"
+}
+
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+variable "image_version" {
+  type        = "string"
+  description = "Geotrellis Transit Image version"
+}
+
+variable "cdn_price_class" {
+  default = "PriceClass_200"
+}
+
+variable "ssl_certificate_arn" {
+  default = "arn:aws:acm:us-east-1:896538046175:certificate/a416c2af-00dd-4afd-8c71-dd32edefa839"
+}
+
+variable "chatta_ecs_desired_count" {
+  default = "1"
+}
+
+variable "chatta_ecs_min_count" {
+  default = "1"
+}
+
+variable "chatta_ecs_max_count" {
+  default = "2"
+}
+
+variable "chatta_ecs_deployment_min_percent" {
+  default = "100"
+}
+
+variable "chatta_ecs_deployment_max_percent" {
+  default = "200"
+}


### PR DESCRIPTION
# Overview

Add terraform resources for `chatta.geotrellis.io`. This PR makes the following additions:
- Use the `terraform-aws-ecs-web-service` to define a service for the `gt-chatta` container.
- Add a CloudFront distribution with the ECS service as an origin.
- Access core infrastructure remote state information with the `terraform_remote_state` data source
- Add firewall rules to allow communication between the Chatta webservice ALB and the Container Instance, and allow HTTP(S) ingress to the ALB from the public internet.
- Travis CI config

# Testing
- https://chatta.geotrellis.io