### PR TITLE
Remove default value for ssl_certificate_arn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ ingest-data.zip
 deployment/terraform/.terraform
 *.tfplan
 *.tfstate*
+*.tfvars

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,42 @@
+# Amazon Web Services Deployment
+
+Amazon Web Services deployment is driven by [Terraform](https://terraform.io/) and the [AWS Command Line Interface (CLI)](http://aws.amazon.com/cli/).
+
+## Table of Contents
+
+* [AWS Credentials](#aws-credentials)
+* [Terraform](#terraform)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `geotrellis`:
+
+```bash
+$ aws --profile geotrellis configure
+AWS Access Key ID [********************]:
+AWS Secret Access Key [********************]:
+Default region name [us-east-1]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Terraform
+
+Next, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+$ export GT_CHATTA_SETTINGS_BUCKET="geotrellis-site-production-config-us-east-1"
+$ export AWS_PROFILE="geotrellis"
+# TRAVIS_COMMIT is the 7-digit SHA for the commit you want to deploy
+$ export TRAVIS_COMMIT=1a3b5c7
+$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra.sh plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra.sh apply
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.

--- a/deployment/terraform/chatta-demo.tf
+++ b/deployment/terraform/chatta-demo.tf
@@ -21,6 +21,7 @@ resource "aws_ecs_task_definition" "chatta" {
 
 resource "aws_cloudwatch_log_group" "chatta" {
   name = "log${var.environment}ChattaDemo"
+  retention_in_days = "${var.cloudwatch_log_retention_days}"
 
   tags {
     Environment = "${var.environment}"

--- a/deployment/terraform/chatta-demo.tf
+++ b/deployment/terraform/chatta-demo.tf
@@ -27,6 +27,10 @@ resource "aws_cloudwatch_log_group" "chatta" {
   }
 }
 
+data "aws_iam_role" "autoscaling" {
+  role_name = "${var.ecs_autoscaling_role_name}"
+}
+
 module "chatta_ecs_service" {
   source = "github.com/azavea/terraform-aws-ecs-web-service?ref=0.2.0"
 
@@ -48,7 +52,7 @@ module "chatta_ecs_service" {
   container_name                 = "gt-chatta"
   container_port                 = "8777"
   ecs_service_role_name          = "${data.terraform_remote_state.core.ecs_service_role_name}"
-  ecs_autoscale_role_arn         = "${data.terraform_remote_state.core.ecs_autoscale_role_arn}"
+  ecs_autoscale_role_arn         = "${data.aws_iam_role.autoscaling.arn}"
 
   project     = "Geotrellis Chatta"
   environment = "${var.environment}"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -25,6 +25,10 @@ variable "cdn_price_class" {
   default = "PriceClass_200"
 }
 
+variable "cloudwatch_log_retention_days" {
+  default = "30"
+}
+
 variable "ecs_autoscaling_role_name" {
   default = "AWSServiceRoleForApplicationAutoScaling_ECSService"
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -25,9 +25,7 @@ variable "cdn_price_class" {
   default = "PriceClass_200"
 }
 
-variable "ssl_certificate_arn" {
-  default = "arn:aws:acm:us-east-1:896538046175:certificate/a416c2af-00dd-4afd-8c71-dd32edefa839"
-}
+variable "ssl_certificate_arn" {}
 
 variable "chatta_ecs_desired_count" {
   default = "1"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -25,6 +25,10 @@ variable "cdn_price_class" {
   default = "PriceClass_200"
 }
 
+variable "ecs_autoscaling_role_name" {
+  default = "AWSServiceRoleForApplicationAutoScaling_ECSService"
+}
+
 variable "ssl_certificate_arn" {}
 
 variable "chatta_ecs_desired_count" {

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,14 @@
+version: '2.1'
+services:
+  terraform:
+    image: "quay.io/azavea/terraform:0.9.6"
+    volumes:
+      - ~/.aws:/root/.aws
+      - ./:/usr/local/src
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE:-geotrellis}
+      - TRAVIS_COMMIT=${TRAVIS_COMMIT}
+      - GT_CHATTA_DEBUG=1
+      - GT_CHATTA_SETTINGS_BUCKET=${GT_CHATTA_SETTINGS_BUCKET:-geotrellis-site-production-config-us-east-1}
+    working_dir: /usr/local/src
+    entrypoint: bash

--- a/scripts/infra
+++ b/scripts/infra
@@ -34,11 +34,14 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         case "${1}" in
             plan)
                 rm -rf .terraform/ terraform.tfstate*
+                aws s3 cp "s3://${GT_CHATTA_SETTINGS_BUCKET}/terraform/chatta/terraform.tfvars" \
+                    "${GT_CHATTA_SETTINGS_BUCKET}.tfvars"
                 terraform init \
                     -backend-config="bucket=${GT_CHATTA_SETTINGS_BUCKET}" \
                     -backend-config="key=terraform/chatta/state"
 
                 terraform plan \
+                          -var-file="${GT_CHATTA_SETTINGS_BUCKET}.tfvars" \
                           -var="image_version=\"${TRAVIS_COMMIT:0:7}\"" \
                           -var="remote_state_bucket=\"${GT_CHATTA_SETTINGS_BUCKET}\"" \
                           -out="${GT_CHATTA_SETTINGS_BUCKET}.tfplan"


### PR DESCRIPTION
# Overview

This PR removes the default value for `ssl_certificate_arn` (which is now outdated) from `variables.tf`, and updates `scripts/infra` to use a .tfvars file to make it easier to override other defaults in the future.

## Changes
- Remove default value for `ssl_certficate_arn`
- Set CloudWatch log retention policy to 30 days
- Updated `scripts/infra` to use a `.tfvars` file.
- Add `docker-compose.ci.yml` for local deployments.
- Add a `memoryReservation` to the ECS task definition to match the Task Definition currently running in Production.
- Add Deployment `README`.

Fixes #49 


# Testing
- Run `scripts/infra` according to the instructions in the new deployment README, ensure no changes are necessary.
```bash
$ export GT_CHATTA_SETTINGS_BUCKET=geotrellis-site-production-config-us-east-1
$ export AWS_PROFILE=geotrellis
$ export TRAVIS_COMMIT=$(git rev-parse --short master)
$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
```

- Visit https://chatta.geotrellis.io. Ensure that the certificate serial number matches the serial number from the ACM console: https://console.aws.amazon.com/acm/home?region=us-east-1#/?id=4704eab3-c3f9-47fc-9568-a70a0038cf60.
<img width="794" alt="screen shot 2018-07-12 at 2 46 55 pm" src="https://user-images.githubusercontent.com/2507188/42653131-8169813c-85e2-11e8-8215-ee905eab8ad7.png">
<img width="471" alt="screen shot 2018-07-12 at 10 44 05 am" src="https://user-images.githubusercontent.com/2507188/42649854-cb081ac4-85d8-11e8-8152-7362ff743b87.png">
